### PR TITLE
use dotnet 3.1 LTS as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim AS dotnet_sdk
+FROM mcr.microsoft.com/dotnet/sdk:3.1-buster AS dotnet_sdk
 
 LABEL maintainer="Sooho <angjin@sooho.io>"
 


### PR DESCRIPTION
[ch3708](https://app.clubhouse.io/sooho/story/3708/dotnet-5-0-1-target-build-docker-image-lib9c-3-x)
[LIb9c](https://github.com/planetarium/lib9c) Repository need dotnet 3.1 version for build project.  
Fix planetql docker image's base image for matching dotnet version with Lib9c